### PR TITLE
Review for DM-4022 (config: remove bad config setting)

### DIFF
--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -6,5 +6,3 @@ config.measurement.load(os.path.join(os.environ['OBS_SUBARU_DIR'], 'config', 'kr
 # config.measurement.load(os.path.join(os.environ['OBS_SUBARU_DIR'], 'config', 'cmodel.py'))
 
 config.measurement.slots.instFlux = None
-
-config.deblend.load(os.path.join(os.environ["OBS_SUBARU_DIR"], "config", "deblend.py"))


### PR DESCRIPTION
There is no deblending in forced photometry!

This is a cherry-pick of HSC's stand-alone commit bae672c.

Conflicts:
	config/forcedPhotCoadd.py