### PR TITLE
DM-5663

### DIFF
--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -9,9 +9,8 @@ from lsst.utils import getPackageDir
 hscConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
 config.load(os.path.join(hscConfigDir, 'isr.py'))
 config.calibrate.photoCal.colorterms.load(os.path.join(hscConfigDir, 'colorterms.py'))
-config.charImage.measurePsf.starSelector.name='objectSize'
-config.charImage.measurePsf.starSelector['objectSize'].widthMin=0.9
-config.charImage.measurePsf.starSelector['objectSize'].fluxMin=4000
+config.charImage.measurePsf.starSelector.widthMin=0.9
+config.charImage.measurePsf.starSelector.fluxMin=4000
 config.calibrate.astrometry.refObjLoader.load(os.path.join(hscConfigDir, "filterMap.py"))
 
 config.calibrate.astrometry.wcsFitter.order = 3

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -15,7 +15,7 @@ config.charImage.detectAndMeasure.detection.background.binSize = 128
 config.calibrate.detectAndMeasure.detection.background.binSize = 128
 
 # PSF determination
-config.charImage.measurePsf.starSelector['objectSize'].sourceFluxField = 'base_PsfFlux_flux'
+config.charImage.measurePsf.starSelector.sourceFluxField = 'base_PsfFlux_flux'
 try:
     import lsst.meas.extensions.psfex.psfexPsfDeterminer
     config.charImage.measurePsf.psfDeterminer["psfex"].spatialOrder = 2


### PR DESCRIPTION
Star selectors are no longer in a registry, so two config
override files needed updating.