### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/python/lsst/obs/subaru/subaruLib.i
+++ b/python/lsst/obs/subaru/subaruLib.i
@@ -45,5 +45,5 @@ namespace std {
 %include "lsst/obs/subaru/HscDistortion.h"
 
 %include "lsst/obs/subaru/Crosstalk.h"
-//%template(vectorCalib) std::vector<boost::shared_ptr<const lsst::afw::image::Calib> >;
+//%template(vectorCalib) std::vector<std::shared_ptr<const lsst::afw::image::Calib> >;
 

--- a/src/HscDistortion.cc
+++ b/src/HscDistortion.cc
@@ -23,7 +23,7 @@
  */
 
 #include "lsst/obs/subaru/HscDistortion.h"
-#include "boost/make_shared.hpp"
+#include <memory>
 
 namespace lsst {
 namespace obs {
@@ -102,7 +102,7 @@ HscDistortion::HscDistortion(
 
 PTR(afw::geom::XYTransform) HscDistortion::clone() const
 {
-    return boost::make_shared<HscDistortion>(_skyToCcd, _ccdToSky, _scaling*afw::geom::radians,
+    return std::make_shared<HscDistortion>(_skyToCcd, _ccdToSky, _scaling*afw::geom::radians,
                                              _inversionTolerance, _maxIterations);
 }
 


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
