### PR TITLE
Update config overrides for star selector in a registry

### DIFF
--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -9,8 +9,8 @@ from lsst.utils import getPackageDir
 hscConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
 config.load(os.path.join(hscConfigDir, 'isr.py'))
 config.calibrate.photoCal.colorterms.load(os.path.join(hscConfigDir, 'colorterms.py'))
-config.charImage.measurePsf.starSelector.widthMin=0.9
-config.charImage.measurePsf.starSelector.fluxMin=4000
+config.charImage.measurePsf.starSelector["objectSize"].widthMin=0.9
+config.charImage.measurePsf.starSelector["objectSize"].fluxMin=4000
 config.calibrate.refObjLoader.load(os.path.join(hscConfigDir, "filterMap.py"))
 
 config.calibrate.astrometry.wcsFitter.order = 3

--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -9,8 +9,8 @@ from lsst.utils import getPackageDir
 hscConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
 config.load(os.path.join(hscConfigDir, 'isr.py'))
 config.calibrate.photoCal.colorterms.load(os.path.join(hscConfigDir, 'colorterms.py'))
-config.charImage.measurePsf.starSelector["objectSize"].widthMin=0.9
-config.charImage.measurePsf.starSelector["objectSize"].fluxMin=4000
+config.charImage.measurePsf.starSelector["objectSize"].widthMin = 0.9
+config.charImage.measurePsf.starSelector["objectSize"].fluxMin = 4000
 config.calibrate.refObjLoader.load(os.path.join(hscConfigDir, "filterMap.py"))
 
 config.calibrate.astrometry.wcsFitter.order = 3
@@ -18,7 +18,7 @@ config.calibrate.astrometry.matcher.maxMatchDistArcSec = 2.0
 config.calibrate.astrometry.matcher.maxOffsetPix = 750
 
 # Do not use NO_DATA pixels for fringe subtraction.
-config.isr.fringe.stats.badMaskPlanes=['SAT', 'NO_DATA']
+config.isr.fringe.stats.badMaskPlanes = ['SAT', 'NO_DATA']
 
 config.charImage.detectAndMeasure.measurement.plugins["base_Jacobian"].pixelScale = 0.168
 config.calibrate.detectAndMeasure.measurement.plugins["base_Jacobian"].pixelScale = 0.168

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -17,7 +17,7 @@ config.calibrate.detectAndMeasure.detection.background.load(bgFile)
 
 # PSF determination
 config.charImage.measurePsf.reserveFraction = 0.2
-config.charImage.measurePsf.starSelector.sourceFluxField = 'base_PsfFlux_flux'
+config.charImage.measurePsf.starSelector["objectSize"].sourceFluxField = 'base_PsfFlux_flux'
 try:
     import lsst.meas.extensions.psfex.psfexPsfDeterminer
     config.charImage.measurePsf.psfDeterminer["psfex"].spatialOrder = 2


### PR DESCRIPTION
The star selector for the measurePsf subtask of ProcessCcdTask
is now a RegistryField instead of a ConfigurableField;
update the config overrides accordingly.