### PR TITLE
DM-8013: subtractXTalk is fragile

### DIFF
--- a/python/lsst/obs/subaru/crosstalk.py
+++ b/python/lsst/obs/subaru/crosstalk.py
@@ -229,7 +229,8 @@ def subtractXTalk(mi, coeffs, minPixelToMask=45000, crosstalkStr="CROSSTALK"):
     # the ones that we label as causing crosstalk; in reality all pixels cause crosstalk)
     #
     tempStr = "TEMP"                    # mask plane used to record the bright pixels that we need to mask
-    mi.getMask().addMaskPlane(tempStr)
+    msk = mi.getMask()
+    msk.addMaskPlane(tempStr)
     try:
         fs = afwDetect.FootprintSet(mi, afwDetect.Threshold(minPixelToMask), tempStr)
 


### PR DESCRIPTION
This makes `subtractXTalk` more robust. Previously, if an exception was raised in the (large) `try` block, the `msk` variable referred to in the `finally` may be undefined. This fix defines `msk` earlier.