### PR TITLE
activate measurements used in s16a production afterburner

### DIFF
--- a/config/convolvedFluxes.py
+++ b/config/convolvedFluxes.py
@@ -1,0 +1,9 @@
+# Enable measurement of convolved fluxes
+# 'config' is a SourceMeasurementConfig
+try:
+    import lsst.meas.extensions.convolved  # noqa: Load flux.convolved algorithm
+except ImportError as exc:
+    print("Cannot import lsst.meas.extensions.convolved (%s): disabling convolved flux measurements" % (exc,))
+else:
+    config.plugins.names.add("ext_convolved_ConvolvedFlux")
+    # Default values for 'seeing' and 'aperture.radii' are suitable for HSC.

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -1,9 +1,11 @@
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.meas.base import CircularApertureFluxAlgorithm
 
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "apertures.py"))
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "kron.py"))
+config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "convolvedFluxes.py"))
 config.load(os.path.join(getPackageDir("obs_subaru"), "config", "cmodel.py"))
 
 config.measurement.slots.instFlux = None
@@ -14,3 +16,28 @@ config.measurement.plugins['base_PixelFlags'].masksFpAnywhere.append('BRIGHT_OBJ
 
 config.catalogCalculation.plugins.names = ["base_ClassificationExtendedness"]
 config.measurement.slots.psfFlux = "base_PsfFlux"
+
+def doUndeblended(config, algName, fluxList=None):
+    """Activate undeblended measurements of algorithm
+
+    Parameters
+    ----------
+    algName : `str`
+        Algorithm name.
+    fluxList : `list` of `str`, or `None`
+        List of flux columns to register for aperture correction. If `None`,
+        then this will be the `algName` appended with `_flux`.
+    """
+    if algName not in config.measurement.plugins:
+        return
+    if fluxList is None:
+        fluxList = [algName + "_flux"]
+    config.measurement.undeblended.names.add(algName)
+    config.measurement.undeblended[algName] = config.measurement.plugins[algName]
+    for flux in fluxList:
+        config.applyApCorr.proxies["undeblended_" + flux] = flux
+
+
+doUndeblended(config, "base_PsfFlux")
+doUndeblended(config, "ext_photometryKron_KronFlux")
+doUndeblended(config, "base_CircularApertureFlux", [])  # No aperture correction for circular apertures

--- a/config/measureCoaddSources.py
+++ b/config/measureCoaddSources.py
@@ -5,6 +5,7 @@ from lsst.utils import getPackageDir
 
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "apertures.py"))
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "kron.py"))
+config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "convolvedFluxes.py"))
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsm.py"))
 config.load(os.path.join(getPackageDir("obs_subaru"), "config", "cmodel.py"))
 

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -57,6 +57,7 @@ config.calibrate.detection.isotropicGrow = True
 config.charImage.load(os.path.join(configDir, "cmodel.py"))
 config.charImage.measurement.load(os.path.join(configDir, "apertures.py"))
 config.charImage.measurement.load(os.path.join(configDir, "kron.py"))
+config.charImage.measurement.load(os.path.join(configDir, "convolvedFluxes.py"))
 config.charImage.measurement.load(os.path.join(configDir, "hsm.py"))
 if "ext_shapeHSM_HsmShapeRegauss" in config.charImage.measurement.plugins:
     # no deblending has been done
@@ -74,3 +75,8 @@ config.calibrate.deblend.maxFootprintArea = 10000
 
 config.charImage.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
 config.calibrate.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+
+# Convolved fluxes can fail for small target seeing if the observation seeing is larger
+if "ext_convolved_ConvolvedFlux" in config.charImage.measurement.plugins:
+    names = config.charImage.measurement.plugins["ext_convolved_ConvolvedFlux"].getAllResultNames()
+    config.charImage.measureApCorr.allowFailure += names


### PR DESCRIPTION
The HSC s16a production's afterburner included two measurements features
which have been ported to LSST: measurement on the undeblended image (to
allow potentially useful measurements where the deblender fails, and to
compare with software that doesn't use a deblender), and measurement of
convolved fluxes (to provide fluxes in multiple bands with a common
seeing, e.g., for photometric redshifts). This patch activates these
features for HSC and Suprime-Cam.