### PR TITLE
DM-6824: Use meas.algorithms.astrometrySourceSelector in measOptimisticB

### DIFF
--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -18,7 +18,7 @@ for refObjLoader in (config.calibrate.astromRefObjLoader,
     refObjLoader.load(os.path.join(hscConfigDir, "filterMap.py"))
 
 # Set to match defaults curretnly used in HSC production runs (e.g. S15B)
-config.calibrate.astrometry.matcher.sourceFluxType = 'Psf'
+config.calibrate.astrometry.matcher.sourceSelector.active.sourceFluxType = 'Psf'
 config.calibrate.astrometry.matcher.allowedNonperpDeg = 0.2
 config.calibrate.astrometry.matcher.maxRotationDeg = 1.145916
 config.calibrate.astrometry.wcsFitter.numRejIter = 3


### PR DESCRIPTION
Added compliance with the new sourceSelector object in meas_astrom/matchOptimisticB as part of tickets/DM-6824. This required a small change to how HSC specific parameters were set in config/hsc/processCdd.py