### PR TITLE
config: adapt to removal of DarkConfig

### DIFF
--- a/config/hsc/dark.py
+++ b/config/hsc/dark.py
@@ -4,8 +4,6 @@ from lsst.utils import getPackageDir
 
 config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
 
-config.darkTime = None
-
 config.isr.doBias = True
 config.repair.cosmicray.nCrPixelMax = 1000000
 config.repair.cosmicray.minSigma = 5.0


### PR DESCRIPTION
Darktime now comes from the VisitInfo rather than a header
keyword.