### PR TITLE
DM-9186: Create hscIsr.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ bin/registryInfo.py
 bin/showCamera.py
 bin/showDither.py
 bin/showPsfs.py
+bin/hscIsr.py

--- a/bin.src/hscIsr.py
+++ b/bin.src/hscIsr.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+from lsst.obs.subaru.isr import SubaruIsrTask
+SubaruIsrTask.parseAndRun()

--- a/config/hsc/isr.py
+++ b/config/hsc/isr.py
@@ -1,30 +1,29 @@
 # Configuration for HSC ISR
+# Note that config should be an instance of SubaruIsrConfig
 import os.path
 
 from lsst.utils import getPackageDir
 
-from lsst.obs.subaru.isr import SubaruIsrTask
-config.isr.retarget(SubaruIsrTask)
 from lsst.obs.subaru.crosstalk import CrosstalkTask
-config.isr.crosstalk.retarget(CrosstalkTask)
+config.crosstalk.retarget(CrosstalkTask)
 
-config.isr.overscanFitType = "AKIMA_SPLINE"
-config.isr.overscanOrder = 30
-config.isr.doBias = True # Overscan is fairly efficient at removing bias level, but leaves a line in the middle
-config.isr.doDark = True # Required especially around CCD 33
-config.isr.doFringe = True
-config.isr.fringe.filters = ['y', 'N921']
-config.isr.doWrite = False
-config.isr.doCrosstalk = True
-config.isr.doGuider = False
-config.isr.doBrighterFatter = True
+config.overscanFitType = "AKIMA_SPLINE"
+config.overscanOrder = 30
+config.doBias = True # Overscan is fairly efficient at removing bias level, but leaves a line in the middle
+config.doDark = True # Required especially around CCD 33
+config.doFringe = True
+config.fringe.filters = ['y', 'N921']
+config.doWrite = False
+config.doCrosstalk = True
+config.doGuider = False
+config.doBrighterFatter = True
 
 # These values from RHL's report on "HSC July Commissioning Data" (2013-08-23)
-config.isr.crosstalk.coeffs.values = [
+config.crosstalk.coeffs.values = [
     0.0e-6, -125.0e-6, -149.0e-6, -156.0e-6,
     -124.0e-6, 0.0e-6, -132.0e-6, -157.0e-6,
     -171.0e-6, -134.0e-6, 0.0e-6, -153.0e-6,
     -157.0e-6, -151.0e-6, -137.0e-6, 0.0e-6,
 ]
 
-config.isr.vignette.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "vignette.py"))
+config.vignette.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "vignette.py"))

--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -5,9 +5,11 @@ HSC-specific overrides for ProcessCcdTask
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
 
 hscConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
-config.load(os.path.join(hscConfigDir, 'isr.py'))
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(hscConfigDir, 'isr.py'))
 config.calibrate.photoCal.colorterms.load(os.path.join(hscConfigDir, 'colorterms.py'))
 config.charImage.measurePsf.starSelector["objectSize"].widthMin = 0.9
 config.charImage.measurePsf.starSelector["objectSize"].fluxMin = 4000


### PR DESCRIPTION
Provides ability to do overscan and bias subtraction without any other
processing.  Useful for pinhole images.