### PR TITLE
config: update ISR for calib construction

### DIFF
--- a/config/hsc/bias.py
+++ b/config/hsc/bias.py
@@ -1,6 +1,8 @@
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
 
-config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
 config.isr.doBrighterFatter = False

--- a/config/hsc/dark.py
+++ b/config/hsc/dark.py
@@ -1,8 +1,10 @@
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
 
-config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
 
 config.isr.doBias = True
 config.repair.cosmicray.nCrPixelMax = 1000000

--- a/config/hsc/flat.py
+++ b/config/hsc/flat.py
@@ -1,8 +1,10 @@
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
 
-config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
 
 from lsst.obs.hsc.calibs import HscFlatCombineTask
 config.combination.retarget(HscFlatCombineTask)

--- a/config/hsc/fringe.py
+++ b/config/hsc/fringe.py
@@ -1,7 +1,9 @@
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
 
-config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "isr.py"))
 
 config.isr.doBrighterFatter = False


### PR DESCRIPTION
DM-9353 changed how ISR was configured for HSC. This patch
adapts the calib construction configurations to that change.