### PR TITLE
DM-9438: Switch default reference catalog for HSC to PS1 in LSST format

### DIFF
--- a/config/Mosaic.py
+++ b/config/Mosaic.py
@@ -1,13 +1,8 @@
 import os
 from lsst.utils import getPackageDir
-from lsst.pipe.tasks.setConfigFromEups import setPhotocalConfigFromEups, setAstrometryConfigFromEups
+from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
-setPhotocalConfigFromEups(config)
-
-menu = {"ps1*": {}, # Defaults are fine
-        "sdss*": {"astrom.filterMap": {"y": "z"}}, # No y-band, use z instead
-        "2mass*": {"astrom.filterMap": {ff: "J" for ff in "grizy"}}, # No optical bands, use J instead
-        }
-setAstrometryConfigFromEups(config, menu)
-
+config.loadAstrom.retarget(LoadIndexedReferenceObjectsTask)
+config.loadAstrom.ref_dataset_name = "ps1_pv3_3pi_20170110"
 config.loadAstrom.load(os.path.join(getPackageDir("obs_subaru"), "config", "filterMap.py"))
+config.photoCatName = "ps1_pv3_3pi_20170110"

--- a/config/measureCoaddSources.py
+++ b/config/measureCoaddSources.py
@@ -2,6 +2,7 @@
 
 import os.path
 from lsst.utils import getPackageDir
+from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "apertures.py"))
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "kron.py"))
@@ -11,7 +12,8 @@ config.load(os.path.join(getPackageDir("obs_subaru"), "config", "cmodel.py"))
 
 config.deblend.load(os.path.join(getPackageDir("obs_subaru"), "config", "deblend.py"))
 
-# AstrometryTask has a refObjLoader subtask which accepts the filter map.
+config.match.refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+config.match.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 config.match.refObjLoader.load(os.path.join(getPackageDir("obs_subaru"), "config", "filterMap.py"))
 
 #

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
 configDir = os.path.join(getPackageDir("obs_subaru"), "config")
 bgFile = os.path.join(configDir, "background.py")
@@ -32,7 +33,9 @@ for refObjLoader in (config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader,
                      config.charImage.refObjLoader,
                      ):
+    refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
     refObjLoader.load(os.path.join(getPackageDir("obs_subaru"), "config", "filterMap.py"))
+    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 
 # Better astrometry matching
 config.calibrate.astrometry.matcher.numBrightStars = 150
@@ -43,16 +46,7 @@ config.charImage.catalogCalculation.plugins['base_ClassificationExtendedness'].f
 config.calibrate.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
 
 config.calibrate.photoCal.applyColorTerms = True
-
-from lsst.pipe.tasks.setConfigFromEups import setConfigFromEups
-menu = {"ps1*": {}, # Defaults are fine
-        "sdss*": {"photoRefObjLoader.filterMap": {"y": "z"},
-                  "astromRefObjLoader.filterMap": {"y": "z"}}, # No y-band, use z instead
-        "2mass*": {"photoRefObjLoader.filterMap": {ff: "J" for ff in "grizy"},
-                   "astromRefObjLoader.filterMap": {ff: "J" for ff in "grizy"}}, # No optical, use J instead
-        "10*": {}, # Match the empty astrometry_net_data version for use without a ref catalog
-        }
-setConfigFromEups(config.calibrate.photoCal, config.calibrate, menu)
+config.calibrate.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
 
 # Demand astrometry and photoCal succeed
 config.calibrate.requireAstrometry = True


### PR DESCRIPTION
This frees us from dependency on astrometry_net, and removes our reliance
on eups for setting the configuration.