### PR TITLE
obs_subaru DM-9885: Rename deepCoadd_srcMatch as deepCoadd_measMatch

### DIFF
--- a/policy/HscMapper.paf
+++ b/policy/HscMapper.paf
@@ -352,10 +352,10 @@ datasets: {
         tables:        raw
         tables:        raw_visit
     }
-    deepCoadd_srcMatch: {
+    deepCoadd_measMatch: {
         template:      "deepCoadd-results/%(filter)s/%(tract)d/%(patch)s/srcMatch-%(filter)s-%(tract)d-%(patch)s.fits"
     }
-    deepCoadd_srcMatchFull: {
+    deepCoadd_measMatchFull: {
         template:      "deepCoadd-results/%(filter)s/%(tract)d/%(patch)s/srcMatchFull-%(filter)s-%(tract)d-%(patch)s.fits"
     }
     deepCoadd_calexp_background: {

--- a/policy/SuprimecamMapper.paf
+++ b/policy/SuprimecamMapper.paf
@@ -312,8 +312,11 @@ datasets: {
         tables:        raw
         tables:        raw_visit
     }
-    deepCoadd_srcMatch: {
+    deepCoadd_measMatch: {
         template:      "deepCoadd-results/%(filter)s/%(tract)d/%(patch)s/srcMatch-%(filter)s-%(tract)d-%(patch)s.fits"
+    }
+    deepCoadd_measMatchFull: {
+        template:      "deepCoadd-results/%(filter)s/%(tract)d/%(patch)s/srcMatchFull-%(filter)s-%(tract)d-%(patch)s.fits"
     }
     deepCoadd_calexpBackground: {
         template:      "deepCoadd-results/%(filter)s/%(tract)d/%(patch)s/bkgd-%(filter)s-%(tract)d-%(patch)s.fits"


### PR DESCRIPTION
The naming appears to be an error during the port of functionality
from HSC. Renamed in order to make clearer the relationship with the
deepCoadd_meas catalog.

Did not change the file template, so as not to invalidate existing
processed data.