### PR TITLE
HscMapper: cache the camera object

### DIFF
--- a/tests/testCamera.py
+++ b/tests/testCamera.py
@@ -71,7 +71,9 @@ class CameraTestCase(lsst.utils.tests.TestCase):
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
-    pass
+    def setUp(self):
+        HscMapper.clearCache()
+        lsst.utils.tests.MemoryTestCase.setUp(self)
 
 
 def setup_module(module):

--- a/tests/testDistortion.py
+++ b/tests/testDistortion.py
@@ -1257,7 +1257,9 @@ def getVerificationData():
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
-    pass
+    def setUp(self):
+        HscMapper.clearCache()
+        lsst.utils.tests.MemoryTestCase.setUp(self)
 
 
 def setup_module(module):

--- a/tests/testRepository.py
+++ b/tests/testRepository.py
@@ -36,6 +36,7 @@ from lsst.obs.base import MakeRawVisitInfo
 from lsst.afw.image import RotType
 from lsst.afw.coord import IcrsCoord, Coord
 from lsst.afw.geom import degrees
+from lsst.obs.hsc import HscMapper
 
 testDataPackage = "testdata_subaru"
 try:
@@ -189,7 +190,9 @@ class GetDataTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(self.butler.get('linearizer', ccdnum=1))
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
-    pass
+    def setUp(self):
+        HscMapper.clearCache()
+        lsst.utils.tests.MemoryTestCase.setUp(self)
 
 
 def setup_module(module):


### PR DESCRIPTION
The lion's share of the time in instantiating a butler goes to
building the camera object, because that involves parsing a Config
with many lines, and a stat call for each line to get the traceback.
We cache the camera once it's built so that subsequent butler
instantiations (e.g., for multiprocessing or pipe_drivers) don't
suffer the same overhead.