### PR TITLE
DM-11090: Identify regression in HSC astrometric matching success rate between w_2017_17 and w_2017_25

### DIFF
--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -26,7 +26,7 @@ config.calibrate.astrometry.matcher.maxRotationDeg = 1.145916
 config.calibrate.astrometry.wcsFitter.numRejIter = 3
 config.calibrate.astrometry.wcsFitter.order = 3
 config.calibrate.astrometry.matcher.maxMatchDistArcSec = 2.0
-config.calibrate.astrometry.matcher.maxOffsetPix = 750
+config.calibrate.astrometry.matcher.maxOffsetPix = 250
 
 # Do not use NO_DATA pixels for fringe subtraction.
 config.isr.fringe.stats.badMaskPlanes = ['SAT', 'NO_DATA']


### PR DESCRIPTION
The expansion of the bbox search radius for reference objects to
bbox + maxOffsetPix (added in DM-9750) caused a significant regression
in the astrometric matching.  It seems this is due to an issue with how
matchOptimisticB is handling large numbers of reference stars.  The
default in obs_subaru of maxOffsetPix = 750 resulted in a significant
number of CCDs failing in processCcd (identified in DM-11020).  Here we
set that default to maxOffsetPix = 250 which effectively results in the
same number of CCDs in the RC dataset passing single frame processing
and equivalent quality based on a comparison of QA plots for the pre-
regression and post-fix runs.