### PR TITLE
Add mappers for QA parquet tables

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -596,4 +596,3 @@ datasets:
     python: __builtin__.str
     storage: TextStorage
     template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d/%(description)s.parq
-

--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -577,3 +577,23 @@ datasets:
     python: __builtin__.str
     storage: TextStorage
     template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d/compareVisit-v%(visit)d-%(description)s-%(style)s.png
+
+  # QA tables
+  qaTableCoadd:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: plots/%(filter)s/tract-%(tract)d/%(description)s.parq
+
+  qaTableColor:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: plots/color/tract-%(tract)d/%(description)s.parq
+
+  qaTableVisit:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d/%(description)s.parq
+


### PR DESCRIPTION
DM-12030 adds parquet table persistence to the pipe_analysis scripts.  Here, we add the necessary Butler mappers so that they can get the right filenames.