### PR TITLE
DM-12985: Interpolate before applying B-F correction.

### DIFF
--- a/python/lsst/obs/subaru/isr.py
+++ b/python/lsst/obs/subaru/isr.py
@@ -353,7 +353,7 @@ class SubaruIsrTask(IsrTask):
         if self.config.doSetBadRegions:
             self.setBadRegions(ccdExposure)
 
-        if not interpolationDone:
+        if not interpolationDone or self.config.doNanInterpAfterFlat:
             self.maskAndInterpNan(ccdExposure)
 
         if self.config.qa.doWriteFlattened:


### PR DESCRIPTION
Interpolation can only be done on flat-fielded images, so we apply
(and later remove) both that and the dark (for good measure) before
running B-F.