### PR TITLE
DM-12968: Remove INTERP from bad mask planes for coaddition

### DIFF
--- a/config/assembleCoadd.py
+++ b/config/assembleCoadd.py
@@ -1,4 +1,4 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "INTRP", "NO_DATA",)
+config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.doSigmaClip = False
 config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels)
 config.doMaskBrightObjects = True

--- a/config/assembleCoadd.py
+++ b/config/assembleCoadd.py
@@ -1,4 +1,3 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.doSigmaClip = False
 config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels)
 config.doMaskBrightObjects = True

--- a/config/compareWarpAssembleCoadd.py
+++ b/config/compareWarpAssembleCoadd.py
@@ -1,4 +1,4 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "INTRP", "NO_DATA",)
+config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.subregionSize = (10000, 200)  # 200 rows (since patch width is typically < 10k pixels
 config.doMaskBrightObjects = True
 config.removeMaskPlanes.append("CROSSTALK")

--- a/config/compareWarpAssembleCoadd.py
+++ b/config/compareWarpAssembleCoadd.py
@@ -1,4 +1,3 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.subregionSize = (10000, 200)  # 200 rows (since patch width is typically < 10k pixels
 config.doMaskBrightObjects = True
 config.removeMaskPlanes.append("CROSSTALK")

--- a/config/safeClipAssembleCoadd.py
+++ b/config/safeClipAssembleCoadd.py
@@ -1,4 +1,4 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "INTRP", "NO_DATA",)
+config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels
 config.doMaskBrightObjects = True
 config.removeMaskPlanes.append("CROSSTALK")

--- a/config/safeClipAssembleCoadd.py
+++ b/config/safeClipAssembleCoadd.py
@@ -1,4 +1,3 @@
-config.badMaskPlanes = ("BAD", "EDGE", "SAT", "NO_DATA",)
 config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels
 config.doMaskBrightObjects = True
 config.removeMaskPlanes.append("CROSSTALK")


### PR DESCRIPTION
Interpolation is pretty good for e.g. cosmic rays, and
leaving out pixels leads to INEXACT_PSF masks on the coadd,
which we'd like to minimize.