### PR TITLE
DM-13388: config: activate sky correction by default

### DIFF
--- a/config/hsc/makeCoaddTempExp.py
+++ b/config/hsc/makeCoaddTempExp.py
@@ -1,1 +1,2 @@
 config.doApplyUberCal = True
+config.doApplySkyCorr = True


### PR DESCRIPTION
To ensure everyone is using the latest procedures and code, enable
sky correction by default for HSC.