### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -609,6 +609,8 @@ datasets:
     - raw
     - raw_visit
     template: config/processFocusSweep.py
+  apPipe_metadata:
+    template: '%(pointing)05d/%(filter)s/apPipe_metadata/%(visit)07d-%(ccd)03d.boost'
 
   # Plots for analysis QA
   plotCoadd:

--- a/policy/SuprimecamMapper.yaml
+++ b/policy/SuprimecamMapper.yaml
@@ -501,3 +501,5 @@ datasets:
     python: hsc.pipe.tasks.multiband.MultiBandConfig
     storage: ConfigStorage
     template: config/multiband.py
+  apPipe_metadata:
+    template: '%(pointing)05d/%(filter)s/apPipe_metadata/%(visit)07d%(ccd)1d.boost'


### PR DESCRIPTION
This PR registers a dataset mapping for metadata persisted by `ApPipeTask`. The config dataset is delegated to `obs_base`.