### PR TITLE
DM-14008: Enable transmission curve coaddition for HSC by default.

### DIFF
--- a/config/hsc/assembleCoadd.py
+++ b/config/hsc/assembleCoadd.py
@@ -1,2 +1,7 @@
-config.doApplyUberCal = True
+import os.path
+from lsst.utils import getPackageDir
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "coaddBase.py"))
+
 config.doAttachTransmissionCurve = True

--- a/config/hsc/assembleCoadd.py
+++ b/config/hsc/assembleCoadd.py
@@ -1,1 +1,2 @@
 config.doApplyUberCal = True
+config.doAttachTransmissionCurve = True

--- a/config/hsc/coaddBase.py
+++ b/config/hsc/coaddBase.py
@@ -1,0 +1,1 @@
+config.doApplyUberCal = True

--- a/config/hsc/compareWarpAssembleCoadd.py
+++ b/config/hsc/compareWarpAssembleCoadd.py
@@ -1,2 +1,7 @@
-config.doApplyUberCal = True
+import os.path
+from lsst.utils import getPackageDir
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "assembleCoadd.py"))
+
 config.assembleStaticSkyModel.doApplyUberCal = True

--- a/config/hsc/makeCoaddTempExp.py
+++ b/config/hsc/makeCoaddTempExp.py
@@ -1,2 +1,7 @@
-config.doApplyUberCal = True
+import os.path
+from lsst.utils import getPackageDir
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "coaddBase.py"))
+
 config.doApplySkyCorr = True


### PR DESCRIPTION
Should have been done long ago, but was overlooked somehow.