### PR TITLE
DM-14520: don't create transmission curves for guider sensors.

### DIFF
--- a/python/lsst/obs/hsc/makeTransmissionCurves.py
+++ b/python/lsst/obs/hsc/makeTransmissionCurves.py
@@ -122,7 +122,7 @@ def getSensorTransmission():
     is valid after the date provided in the key.
     """
     qe = readTransmissionCurveFromFile("qe_ccd_HSC.txt", atMin=0.0, atMax=0.0)
-    return {HSC_BEGIN: {n: qe for n in range(116)}}
+    return {HSC_BEGIN: {n: qe for n in range(112)}}
 
 
 def getAtmosphereTransmission():

--- a/tests/test_makeTransmissionCurves.py
+++ b/tests/test_makeTransmissionCurves.py
@@ -56,7 +56,7 @@ class MakeTransmissionCurvesTest(lsst.utils.tests.TestCase):
         wavelengths = np.linspace(4000, 12000, 100)
         point = Point2D(200, 10)
         for sensors in makeTransmissionCurves.getSensorTransmission().values():
-            for i in range(116):
+            for i in range(112):
                 curve = sensors[i]
                 throughputs = curve.sampleAt(point, wavelengths)
                 siliconTransparent = wavelengths > 11000


### PR DESCRIPTION
HSC guider CCDs are not included in cameraGeom, so including them in the transmission curves led to some inconsistencies when iterating over all CCDs in different ways.