### PR TITLE
DM-14325: deepDiff datasets not supported by HSC

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -174,6 +174,10 @@ exposures:
     - raw
     - raw_visit
     template: '%(pointing)05d/%(filter)s/thumbs/flattened-%(visit)07d-%(ccd)03d.fits'
+  deepDiff_differenceExp:
+    template: 'deepDiff/%(pointing)05d/%(filter)s/DIFFEXP-%(visit)07d-%(ccd)03d.fits'
+  deepDiff_matchedExp:
+    template: 'deepDiff/%(pointing)05d/%(filter)s/MATCHEDEXP-%(visit)07d-%(ccd)03d.fits'
 
 calibrations:
   bias:
@@ -384,6 +388,12 @@ datasets:
     storage: FitsCatalogStorage
     tables: raw_skytile
     template: deepCoadd-diff/%(filter)s/%(tract)d/%(patch)s/diffsrc-%(filter)s-%(tract)d-%(patch)s-%(visit)d.fits
+  deepDiff_metadata:
+    template: '%(pointing)05d/%(filter)s/deepDiff_metadata/deepDiff_metadata-%(visit)07d-%(ccd)03d.boost'
+  deepDiff_diaSrc:
+    template: 'deepDiff/%(pointing)05d/%(filter)s/DIASRC-%(visit)07d-%(ccd)03d.fits'
+  deepDiff_kernelSrc:
+    template: 'deepDiff/%(pointing)05d/%(filter)s/KERNELSRC-%(visit)07d-%(ccd)03d.fits'
   warppsf:
     persistable: Psf
     python: lsst.afw.detection.Psf


### PR DESCRIPTION
This PR adds obs-specific templates for the five dataset types produced by `ImageDifferenceTask`. I've tried to stick to the conventions followed by existing datasets.