### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/hsc/isr.py
+++ b/config/hsc/isr.py
@@ -1,10 +1,11 @@
-# Configuration for HSC ISR
-# Note that config should be an instance of SubaruIsrConfig
+"""
+HSC-specific overrides for IsrTask
+"""
 import os.path
 
 from lsst.utils import getPackageDir
-
 from lsst.obs.subaru.crosstalk import CrosstalkTask
+
 config.crosstalk.retarget(CrosstalkTask)
 
 config.overscanFitType = "AKIMA_SPLINE"
@@ -13,6 +14,9 @@ config.doBias = True # Overscan is fairly efficient at removing bias level, but 
 config.doDark = True # Required especially around CCD 33
 config.doFringe = True
 config.fringe.filters = ['y', 'N921', 'N926', 'N973', 'N1010']
+
+# Do not use NO_DATA pixels for fringe subtraction.
+config.fringe.stats.badMaskPlanes = ['SAT', 'NO_DATA']
 config.fringe.stats.badMaskPlanes += ["SUSPECT"]  # stray light correction unavailable
 config.doWrite = False
 config.doCrosstalk = True

--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -7,17 +7,19 @@ import os.path
 from lsst.utils import getPackageDir
 from lsst.obs.subaru.isr import SubaruIsrTask
 
-hscConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
+
 config.isr.retarget(SubaruIsrTask)
-config.isr.load(os.path.join(hscConfigDir, 'isr.py'))
-config.calibrate.photoCal.colorterms.load(os.path.join(hscConfigDir, 'colorterms.py'))
+config.isr.load(os.path.join(ObsConfigDir, 'isr.py'))
+
+config.calibrate.photoCal.colorterms.load(os.path.join(ObsConfigDir, 'colorterms.py'))
 config.charImage.measurePsf.starSelector["objectSize"].widthMin = 0.9
 config.charImage.measurePsf.starSelector["objectSize"].fluxMin = 4000
 for refObjLoader in (config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader,
                      config.charImage.refObjLoader,
                      ):
-    refObjLoader.load(os.path.join(hscConfigDir, "filterMap.py"))
+    refObjLoader.load(os.path.join(ObsConfigDir, "filterMap.py"))
 
 # Set to match defaults curretnly used in HSC production runs (e.g. S15B)
 config.calibrate.astrometry.wcsFitter.numRejIter = 3
@@ -30,9 +32,6 @@ for matcher in (config.charImage.ref_match.matcher,
     matcher.maxRotationDeg = 1.145916
     matcher.maxMatchDistArcSec = 2.0
     matcher.maxOffsetPix = 250
-
-# Do not use NO_DATA pixels for fringe subtraction.
-config.isr.fringe.stats.badMaskPlanes = ['SAT', 'NO_DATA']
 
 config.charImage.measurement.plugins["base_Jacobian"].pixelScale = 0.168
 config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.168

--- a/config/hsc/runIsr.py
+++ b/config/hsc/runIsr.py
@@ -1,0 +1,12 @@
+"""
+HSC-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SubaruIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
+
+config.isr.retarget(SubaruIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -7,8 +7,9 @@ from lsst.utils import getPackageDir
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 from lsst.meas.algorithms import ColorLimit
 
-configDir = os.path.join(getPackageDir("obs_subaru"), "config")
-bgFile = os.path.join(configDir, "background.py")
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config")
+
+bgFile = os.path.join(ObsConfigDir, "background.py")
 
 # Cosmic rays and background estimation
 config.charImage.repair.cosmicray.nCrPixelMax = 1000000
@@ -67,18 +68,18 @@ config.charImage.detection.isotropicGrow = True
 config.calibrate.detection.isotropicGrow = True
 
 # Activate calibration of measurements: required for aperture corrections
-config.charImage.load(os.path.join(configDir, "cmodel.py"))
-config.charImage.measurement.load(os.path.join(configDir, "apertures.py"))
-config.charImage.measurement.load(os.path.join(configDir, "kron.py"))
-config.charImage.measurement.load(os.path.join(configDir, "convolvedFluxes.py"))
-config.charImage.measurement.load(os.path.join(configDir, "hsm.py"))
+config.charImage.load(os.path.join(ObsConfigDir, "cmodel.py"))
+config.charImage.measurement.load(os.path.join(ObsConfigDir, "apertures.py"))
+config.charImage.measurement.load(os.path.join(ObsConfigDir, "kron.py"))
+config.charImage.measurement.load(os.path.join(ObsConfigDir, "convolvedFluxes.py"))
+config.charImage.measurement.load(os.path.join(ObsConfigDir, "hsm.py"))
 if "ext_shapeHSM_HsmShapeRegauss" in config.charImage.measurement.plugins:
     # no deblending has been done
     config.charImage.measurement.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = ""
 
-config.calibrate.measurement.load(os.path.join(configDir, "apertures.py"))
-config.calibrate.measurement.load(os.path.join(configDir, "kron.py"))
-config.calibrate.measurement.load(os.path.join(configDir, "hsm.py"))
+config.calibrate.measurement.load(os.path.join(ObsConfigDir, "apertures.py"))
+config.calibrate.measurement.load(os.path.join(ObsConfigDir, "kron.py"))
+config.calibrate.measurement.load(os.path.join(ObsConfigDir, "hsm.py"))
 
 # Deblender
 config.charImage.deblend.maskLimits["NO_DATA"] = 0.25 # Ignore sources that are in the vignetted region

--- a/config/suprimecam-mit/isr.py
+++ b/config/suprimecam-mit/isr.py
@@ -1,14 +1,12 @@
-# Configuration for Suprime-Cam-MIT ISR
+"""
+SuprimeCam (MIT)-specific overrides for IsrTask
+"""
+config.doBias = False
+config.doDark = False
+config.doCrosstalk = False
+config.doLinearize = False
+config.doWrite = False
+config.doDefect = True
 
-from lsst.obs.subaru.isr import SuprimeCamMitIsrTask
-config.isr.retarget(SuprimeCamMitIsrTask)
-
-config.isr.doBias = False
-config.isr.doDark = False
-config.isr.doCrosstalk = False
-config.isr.doLinearize = False
-config.isr.doWrite = False
-config.isr.doDefect = True
-
-config.isr.doFringe = True
-config.isr.fringe.filters = ["I", "i", "z"]
+config.doFringe = True
+config.fringe.filters = ["I", "i", "z"]

--- a/config/suprimecam-mit/processCcd.py
+++ b/config/suprimecam-mit/processCcd.py
@@ -5,10 +5,14 @@ SuprimeCam (MIT)-specific overrides for ProcessCcdTask
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SuprimeCamIsrTask
 
-suprimecamMitConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam-mit")
-config.load(os.path.join(suprimecamMitConfigDir, 'isr.py'))
-config.calibrate.photoCal.colorterms.load(os.path.join(suprimecamMitConfigDir, 'colorterms.py'))
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam-mit")
+
+config.isr.retarget(SuprimeCamIsrTask)
+config.isr.load(os.path.join(ObsConfigDir, 'isr.py'))
+
+config.calibrate.photoCal.colorterms.load(os.path.join(ObsConfigDir, 'colorterms.py'))
 
 config.charImage.measurement.plugins["base_Jacobian"].pixelScale = 0.2
 config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.2

--- a/config/suprimecam-mit/runIsr.py
+++ b/config/suprimecam-mit/runIsr.py
@@ -1,0 +1,12 @@
+"""
+SuprimeCam (MIT)-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SuprimeCamIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam-mit")
+
+config.isr.retarget(SuprimeCamIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/suprimecam/isr.py
+++ b/config/suprimecam/isr.py
@@ -1,15 +1,14 @@
-# Configuration for Suprime-Cam ISR
-
-from lsst.obs.subaru.isr import SuprimeCamIsrTask
-
-config.isr.retarget(SuprimeCamIsrTask)  # custom task that adds guider correction
-config.isr.doBias = True
-config.isr.doDark = False
-config.isr.doWrite = False
+"""
+Suprimecam-specific overrides for IsrTask
+(applied after Subaru overrides in ../processCcd.py)
+"""
+config.doBias = True
+config.doDark = False
+config.doWrite = False
 
 if False:
     # Crosstalk coefficients for SuprimeCam, as crudely measured by RHL
-    config.isr.crosstalk.coeffs = [
+    config.crosstalk.coeffs = [
         0.00e+00, -8.93e-05, -1.11e-04, -1.18e-04,
         -8.09e-05, 0.00e+00, -7.15e-06, -1.12e-04,
         -9.90e-05, -2.28e-05, 0.00e+00, -9.64e-05,
@@ -17,19 +16,19 @@ if False:
     ]
 
 # Crosstalk coefficients derived from Yagi+ 2012
-config.isr.crosstalk.coeffs.crossTalkCoeffs1 = [
+config.crosstalk.coeffs.crossTalkCoeffs1 = [
     0, -0.000148, -0.000162, -0.000167,   # cAA,cAB,cAC,cAD
     -0.000148, 0, -0.000077, -0.000162,     # cBA,cBB,cBC,cBD
     -0.000162, -0.000077, 0, -0.000148,     # cCA,cCB,cCC,cCD
     -0.000167, -0.000162, -0.000148, 0,     # cDA,cDB,cDC,cDD
 ]
-config.isr.crosstalk.coeffs.crossTalkCoeffs2 = [
+config.crosstalk.coeffs.crossTalkCoeffs2 = [
     0, 0.000051, 0.000050, 0.000053,
     0.000051, 0, 0, 0.000050,
     0.000050, 0, 0, 0.000051,
     0.000053, 0.000050, 0.000051, 0,
 ]
-config.isr.crosstalk.coeffs.relativeGainsPreampAndSigboard = [
+config.crosstalk.coeffs.relativeGainsPreampAndSigboard = [
     0.949, 0.993, 0.976, 0.996,
     0.973, 0.984, 0.966, 0.977,
     1.008, 0.989, 0.970, 0.976,

--- a/config/suprimecam/processCcd.py
+++ b/config/suprimecam/processCcd.py
@@ -5,10 +5,14 @@ SuprimeCam-specific overrides for ProcessCcdTask
 import os.path
 
 from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SuprimeCamIsrTask
 
-suprimecamConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam")
-config.load(os.path.join(suprimecamConfigDir, 'isr.py'))
-config.calibrate.photocal.colorterms.load(os.path.join(suprimecamConfigDir, 'colorterms.py'))
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam")
+
+config.isr.retarget(SuprimeCamIsrTask)
+config.isr.load(os.path.join(ObsConfigDir, 'isr.py'))
+
+config.calibrate.photocal.colorterms.load(os.path.join(ObsConfigDir, 'colorterms.py'))
 
 config.charImage.measurement.plugins["base_Jacobian"].pixelScale = 0.2
 config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.2

--- a/config/suprimecam/runIsr.py
+++ b/config/suprimecam/runIsr.py
@@ -1,0 +1,13 @@
+"""
+Suprimecam-specific overrides for RunIsrTask
+(applied after Subaru overrides in ../processCcd.py)
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.subaru.isr import SuprimeCamIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "suprimecam")
+
+config.isr.retarget(SuprimeCamIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
