### PR TITLE
DM-15727: Disable CModel in forcedPhotCcd

### DIFF
--- a/config/forcedPhotCcd.py
+++ b/config/forcedPhotCcd.py
@@ -4,6 +4,5 @@ from lsst.utils import getPackageDir
 
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "apertures.py"))
 config.measurement.load(os.path.join(getPackageDir("obs_subaru"), "config", "kron.py"))
-config.load(os.path.join(getPackageDir("obs_subaru"), "config", "cmodel.py"))
 
 config.measurement.slots.instFlux = None


### PR DESCRIPTION
It doesn't work!
This line has been there for a while, but CModel is explicitly disabled
in ci_hsc when it does forcedPhotCcd, so I conclude this line was added
in error.