### PR TITLE
DM-17428: config: tranpose before interpolation

### DIFF
--- a/config/hsc/assembleCoadd.py
+++ b/config/hsc/assembleCoadd.py
@@ -5,3 +5,4 @@ from lsst.utils import getPackageDir
 config.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "coaddBase.py"))
 
 config.doAttachTransmissionCurve = True
+config.interpImage.transpose = True  # Saturation trails are usually oriented east-west, so along rows


### PR DESCRIPTION
when assembling coadd. HSC observations typically (not always, but
usually) have saturation trails oriented along rows, so transpose
before interpolation, so we interpolate across (not along) the
saturation trails.