### PR TITLE
DM-18577: Use datastore root not a guess from butler root

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -91,7 +91,7 @@ class HscIngestTestCase(lsst.utils.tests.TestCase):
 
     def testInPlace(self):
         # hardlink into repo root manually
-        newPath = os.path.join(self.root, os.path.basename(self.file))
+        newPath = os.path.join(self.butler.datastore.root, os.path.basename(self.file))
         os.link(self.file, newPath)
         self.config.transfer = None
         self.runIngestTest([newPath])


### PR DESCRIPTION
The location that datastore uses to write files is not necessarily the directory containing the butler.yaml file. Update the ingest test code to take that into account.