### PR TITLE
DM-17426: config: use larger initial background subtraction

### DIFF
--- a/config/hsc/focalPlaneBackground.py
+++ b/config/hsc/focalPlaneBackground.py
@@ -1,4 +1,4 @@
 # Configuration for background model of the entire focal-plane
 
-config.xSize = 1024
-config.ySize = 1024
+config.xSize = 8192
+config.ySize = 8192

--- a/config/sky.py
+++ b/config/sky.py
@@ -1,8 +1,0 @@
-from lsst.utils import getPackageDir
-import os
-
-configDir = os.path.join(getPackageDir("obs_subaru"), "config")
-bgFile = os.path.join(configDir, "background.py")
-
-config.detection.background.load(bgFile)
-config.subtractBackground.load(bgFile)

--- a/config/sky2.py
+++ b/config/sky2.py
@@ -1,8 +1,0 @@
-from lsst.utils import getPackageDir
-import os
-
-configDir = os.path.join(getPackageDir("obs_subaru"), "config")
-bgFile = os.path.join(configDir, "background.py")
-
-config.detection.background.load(bgFile)
-config.subtractBackground.load(bgFile)


### PR DESCRIPTION
With the revised background subtraction (three-stage instead of
two), we can use a larger scale for the first background model.