### PR TITLE
DM-19303: config: disable writing postISRCCD

### DIFF
--- a/config/hsc/isr.py
+++ b/config/hsc/isr.py
@@ -132,5 +132,3 @@ config.doUseOpticsTransmission = True
 config.doUseFilterTransmission = True
 config.doUseSensorTransmission = True
 config.doUseAtmosphereTransmission = True
-
-config.doWrite = True

--- a/config/hsc/processCcd.py
+++ b/config/hsc/processCcd.py
@@ -11,6 +11,7 @@ from lsst.meas.astrom import MatchOptimisticBConfig
 ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
 
 config.isr.load(os.path.join(ObsConfigDir, 'isr.py'))
+config.isr.doWrite = False
 
 config.calibrate.photoCal.colorterms.load(os.path.join(ObsConfigDir, 'colorterms.py'))
 config.charImage.measurePsf.starSelector["objectSize"].widthMin = 0.9


### PR DESCRIPTION
It's not needed, and just takes up space.