### PR TITLE
DM-19382: Add dataset for preinterp ISR exp.

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -33,6 +33,8 @@ exposures:
     template: '%(field)s/%(dateObs)s/%(pointing)05d/%(filter)s/HSC-%(visit)07d-%(ccd)03d.fits'
   postISRCCD:
     template: postISRCCD/v%(visit)07d-f%(filter)s/c%(ccd)03d.fits
+  postISRCCD_uninterpolated:
+    template: postISRCCD/v%(visit)07d-f%(filter)s/c%(ccd)03d-preInterp.fits
   icExp:
     template: '%(pointing)05d/%(filter)s/corr/ICEXP-%(visit)07d-%(ccd)03d.fits'
   calexp:


### PR DESCRIPTION
Previously, masking and interpolation was done on a by-defect-type
basis: a set of bad pixels were masked and interpolated, then the
process repeated on different bad pixels. However, this ignores the
case where different types of bad pixels may be contiguous, resulting
in interpolated pixels being derived based on previously interpolated
values.

The new dataset needs a template for the data to be saved.