### PR TITLE
DM-19961: Configure region padding in Gen3 raw ingest.

### DIFF
--- a/config/hsc/bootstrapRepo.py
+++ b/config/hsc/bootstrapRepo.py
@@ -7,7 +7,7 @@ config.skymaps["hsc_rings_v1"].load(os.path.join(getPackageDir("obs_subaru"), "c
                                                  "makeSkyMap.py"))
 config.skymaps["hsc_rings_v1"].load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc",
                                                  "makeSkyMap.py"))
-
+config.raws.load(os.path.join(getPackageDir("obs_subaru"), "config", "hsc", "ingest-gen3.py"))
 config.brightObjectMasks.skymap = "hsc_rings_v1"
 config.brightObjectMasks.collection = "masks/hsc"
 config.calibrations.collection = "calibs/hsc/default"

--- a/config/hsc/ingest-gen3.py
+++ b/config/hsc/ingest-gen3.py
@@ -1,0 +1,1 @@
+config.padRegionAmount = 4000


### PR DESCRIPTION
This should have been part of DM-19638, but was somehow omitted.  Its only effect should be on the Gen3 repo bootstrapping scripts.

See DM-19731 for discussion of why this (conservative) value was chosen.
