### PR TITLE
DM-21421 Add Configs for CharacterizeImageTask

### DIFF
--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -1,0 +1,9 @@
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.meas.algorithms import ColorLimit
+
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config")
+
+charImFile = os.path.join(ObsConfigDir, "charImage.py")
+config.load(charImFile)

--- a/config/hsc/characterizeImage.py
+++ b/config/hsc/characterizeImage.py
@@ -1,0 +1,9 @@
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.meas.algorithms import ColorLimit
+
+ObsConfigDir = os.path.join(getPackageDir("obs_subaru"), "config", "hsc")
+
+charImFile = os.path.join(ObsConfigDir, "charImage.py")
+config.load(charImFile)


### PR DESCRIPTION
CharacterizeImageTask has a default name of characterizeImage, but
the config override file was named charImage reflecting the variable
name in ProcessCcdTask. This adds config files with the correct
names so that they can be appropriately discovered and loaded.