### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -641,6 +641,8 @@ datasets:
     template: config/processFocusSweep.py
   apPipe_metadata:
     template: '%(pointing)05d/%(filter)s/apPipe_metadata/%(visit)07d-%(ccd)03d.yaml'
+  apdb_marker:
+    template: '%(pointing)05d/%(filter)s/apdb/apdb_marker-%(visit)07d-%(ccd)03d.py'
   brighterFatterKernel:  # NB this is for the new cp_pipe generated kernels
     template: calibrations/brighterFatterKernel-%(ccd)03d.pkl
   brighterFatterGain:

--- a/policy/SuprimecamMapper.yaml
+++ b/policy/SuprimecamMapper.yaml
@@ -510,3 +510,5 @@ datasets:
     template: config/multiband.py
   apPipe_metadata:
     template: '%(pointing)05d/%(filter)s/apPipe_metadata/%(visit)07d%(ccd)1d.yaml'
+  apdb_marker:
+    template: '%(pointing)05d/%(filter)s/apdb/apdb_marker-%(visit)07d%(ccd)1d.py'


### PR DESCRIPTION
This PR defines the HSC and SuprimeCam locations for the `apdb_marker` dataset introduced in lsst/obs_base#182.