### PR TITLE
DM-23083: Update large masks for BF convolution issues

### DIFF
--- a/config/hsc/isr.py
+++ b/config/hsc/isr.py
@@ -76,6 +76,7 @@ config.doBrighterFatter = True
 config.brighterFatterMaxIter = 10
 config.brighterFatterThreshold = 1000.0
 config.brighterFatterApplyGain = True
+config.brighterFatterMaskGrowSize = 1
 
 config.doDefect = True
 config.doSaturationInterpolation = True


### PR DESCRIPTION
Expand masks 2 pixels for brighter-fatter correction.