### PR TITLE
DM-23224: Cross-check the schema column names in the Object table

### DIFF
--- a/policy/Object.yaml
+++ b/policy/Object.yaml
@@ -17,7 +17,7 @@ funcs:
     Ra:
         functor: RAColumn
         dataset: meas
-    Dec:
+    Decl:
         functor: DecColumn
         dataset: meas
     # raErr:  not available yet DM-15180


### PR DESCRIPTION
Use Decl instead of Dec because Dec is a reserved word in the SQL