### PR TITLE
DM-24259: Create “stub“ Gen2 HSC dataset for CI testing

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,0 +1,14 @@
+# Config override for lsst.ap.verify.DatasetIngestTask
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.subaru.ingest import HscIngestTask
+
+configDir = os.path.dirname(__file__)
+defectDir = os.path.join(getPackageDir('obs_subaru_data'), 'hsc', 'defects')
+
+config.textDefectPath = defectDir
+config.dataIngester.retarget(HscIngestTask)
+config.dataIngester.load(os.path.join(configDir, 'ingest.py'))
+config.calibIngester.load(os.path.join(configDir, 'ingestCalibs.py'))
+config.defectIngester.load(os.path.join(configDir, 'ingestCuratedCalibs.py'))


### PR DESCRIPTION
This PR adds a config override file for `DatasetIngestTask`, letting `ap_verify` correctly ingest HSC and SuprimeCam datasets. The file is modeled after the [corresponding file](https://github.com/lsst/obs_decam/blob/9352a821ca4358c3659c033014518488b50005e8/config/datasetIngest.py) in `obs_decam`.