### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/config/hsc/isr.py
+++ b/config/hsc/isr.py
@@ -115,8 +115,6 @@ config.fringe.stats.stat = 32
 
 config.doNanInterpAfterFlat = False
 
-config.doAddDistortionModel = True
-
 config.doMeasureBackground = True
 
 config.doCameraSpecificMasking = False

--- a/config/makeBrighterFatterKernel.py
+++ b/config/makeBrighterFatterKernel.py
@@ -30,7 +30,6 @@ config.isr.crosstalk.value.coeffs.values = [0.0e-6, -125.0e-6, -149.0e-6, -156.0
                                             -157.0e-6, -151.0e-6, -137.0e-6, 0.0e-6]
 
 # Added by Merlin:
-config.isr.doAddDistortionModel = False
 config.isr.doUseOpticsTransmission = False
 config.isr.doUseFilterTransmission = False
 config.isr.doUseSensorTransmission = False
@@ -42,6 +41,6 @@ config.isrMandatorySteps = ['doAssembleCcd',  # default
 config.isrForbiddenSteps = ['doApplyGains', 'normalizeGains',  # additional for this obs_package
                             'doStrayLight', 'doTweakFlat',  # additional for this obs_package
                             'doApplyGains', 'normalizeGains', 'doFlat', 'doFringe',  # remainder are defaults
-                            'doAddDistortionModel', 'doBrighterFatter', 'doUseOpticsTransmission',
+                            'doBrighterFatter', 'doUseOpticsTransmission',
                             'doUseFilterTransmission', 'doUseSensorTransmission',
                             'doUseAtmosphereTransmission', 'doStrayLight', 'doTweakFlat']

--- a/config/suprimecam-mit/isr.py
+++ b/config/suprimecam-mit/isr.py
@@ -135,8 +135,6 @@ config.fringe.stats.stat = 32
 
 config.doNanInterpAfterFlat = False
 
-config.doAddDistortionModel = True
-
 config.doMeasureBackground = False
 
 config.doCameraSpecificMasking = True

--- a/config/suprimecam/isr.py
+++ b/config/suprimecam/isr.py
@@ -135,8 +135,6 @@ config.fringe.stats.stat = 32
 
 config.doNanInterpAfterFlat = False
 
-config.doAddDistortionModel = True
-
 config.doMeasureBackground = False
 
 config.doCameraSpecificMasking = True


### PR DESCRIPTION
This PR removes all references to the `IsrConfig.doAddDistortionModel` field, which is no longer  used by `IsrTask`.