### PR TITLE
Add relevant datatypes and configs for processCcdWithFakesDriver

### DIFF
--- a/config/hsc/processCcdWithFakes.py
+++ b/config/hsc/processCcdWithFakes.py
@@ -1,0 +1,12 @@
+"""
+HSC-specific overrides for ProcessCcdWithFakesTask
+(applied after Subaru overrides in ../processCcdWithFakes.py).
+Should be kept up to date with config/hsc/calibrate.py so that
+processCcd and processCcdWithFakes produce the same output.
+"""
+import os.path
+
+
+ObsConfigDir = os.path.dirname(__file__)
+
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.168

--- a/config/hsc/processCcdWithFakesDriver.py
+++ b/config/hsc/processCcdWithFakesDriver.py
@@ -1,0 +1,10 @@
+"""
+hsc-specific overrides for processCcdWithFakesDriverTask
+"""
+import os.path
+
+
+config.doMakeSourceTable = True
+config.processCcdWithFakes.load(os.path.join(os.path.dirname(__file__), "processCcdWithFakes.py"))
+config.transformSourceTable.load(os.path.join(os.path.dirname(__file__), "transformSourceTable.py"))
+config.ignoreCcdList = [9, 104, 105, 106, 107, 108, 109, 110, 111]

--- a/config/processCcdWithFakesDriver.py
+++ b/config/processCcdWithFakesDriver.py
@@ -1,0 +1,9 @@
+"""
+Subaru-specific overrides for ProcessCcdWithFakesDriverTask
+(applied before SuprimeCam- and HSC-specific overrides).
+"""
+import os.path
+
+
+config.processCcdWithFakes.load(os.path.join(os.path.dirname(__file__), "processCcdWithFakes.py"))
+config.ccdKey = 'ccd'

--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -345,6 +345,8 @@ datasets:
     template: '%(pointing)05d/%(filter)s/output/SRC-%(visit)07d-%(ccd)03d.fits'
   source:
     template: '%(pointing)05d/%(filter)s/output/SRC-%(visit)07d-%(ccd)03d.parq'
+  fakes_source:
+    template: '%(pointing)05d/%(filter)s/output/fakes_SRC-%(visit)07d-%(ccd)03d.parq'
   sourceTable:
     template: '%(pointing)05d/%(filter)s/output/sourceTable-%(visit)07d-%(ccd)03d.parq'
   sourceTable_visit:
@@ -452,6 +454,14 @@ datasets:
     - raw
     - raw_visit
     template: '%(pointing)05d/%(filter)s/transformSrcMeasurement_metadata/%(visit)07d-%(ccd)03d.yaml'
+  processCcdWithFakesDriver_metadata:
+    persistable: PropertySet
+    python: lsst.daf.base.PropertySet
+    storage: YamlStorage
+    tables:
+    - raw
+    - raw_visit
+    template: '%(pointing)05d/%(filter)s/processCcdWithFakesDriver_metadata/%(visit)07d.yaml'
   singleFrameDriver_metadata:
     persistable: PropertySet
     python: lsst.daf.base.PropertySet


### PR DESCRIPTION
    Add datatypes for `fakes_source` and
    processCcdWithFakesDriver's metadata as well as a config file
    for processCcdWithFakesDriver.