### PR TITLE
DM-24830: Create dataset class for processed bright star stamps

### DIFF
--- a/policy/HscMapper.yaml
+++ b/policy/HscMapper.yaml
@@ -661,6 +661,8 @@ datasets:
     template: plots/brighterFatterPtc-ccd-%(ccd)03d-amp-%(amp)s.png
   photonTransferCurveDataset:
     template: calibrations/ptc/ptcDataset-ccd%(ccd)03d.pkl
+  brightStarStamps:
+    template: '%(pointing)05d/%(filter)s/brightStarStamps/brightStarStamps-%(filter)s-%(visit)07d-%(ccd)03d.fits'
 
   # Plots for analysis QA
   plotCoadd:


### PR DESCRIPTION
One of 3 PRs for [DM-24830](https://jira.lsstcorp.org/browse/DM-24830) (the other two being obs_base and meas_algorithms).

This adds the HSC template for the bright star datasets introduced with this ticket. The template follows that of other HSC data products that occur at calexp-level.