### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -7,8 +7,8 @@ from lsst.obs.subaru.ingest import HscIngestTask
 configDir = os.path.dirname(__file__)
 defectDir = os.path.join(getPackageDir('obs_subaru_data'), 'hsc', 'defects')
 
-config.textDefectPath = defectDir
+config.curatedCalibPaths = defectDir
 config.dataIngester.retarget(HscIngestTask)
 config.dataIngester.load(os.path.join(configDir, 'ingest.py'))
 config.calibIngester.load(os.path.join(configDir, 'ingestCalibs.py'))
-config.defectIngester.load(os.path.join(configDir, 'ingestCuratedCalibs.py'))
+config.curatedCalibIngester.load(os.path.join(configDir, 'ingestCuratedCalibs.py'))

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -7,7 +7,7 @@ from lsst.obs.subaru.ingest import HscIngestTask
 configDir = os.path.dirname(__file__)
 defectDir = os.path.join(getPackageDir('obs_subaru_data'), 'hsc', 'defects')
 
-config.curatedCalibPaths = defectDir
+config.curatedCalibPaths = [defectDir]
 config.dataIngester.retarget(HscIngestTask)
 config.dataIngester.load(os.path.join(configDir, 'ingest.py'))
 config.calibIngester.load(os.path.join(configDir, 'ingestCalibs.py'))


### PR DESCRIPTION
This PR edits `datasetIngest.py` for the changes made to `DatasetIngestConfig` in lsst/ap_verify#91.