### PR TITLE
DM-24703: Make linearity a subclass of lsst.ip.isr.IsrCalib

### DIFF
--- a/python/lsst/obs/hsc/hscMapper.py
+++ b/python/lsst/obs/hsc/hscMapper.py
@@ -269,7 +269,7 @@ class HscMapper(CameraMapper):
         `bypass_linearizer` twice for the same detector will return _different_ instances of `Linearizer`,
         which share no state.
         """
-        return Linearizer()
+        return Linearizer(detectorId=dataId.get('ccd', None))
 
     def _computeCoaddExposureId(self, dataId, singleFilter):
         """Compute the 64-bit (long) identifier for a coadd.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -183,8 +183,8 @@ class GetDataTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(flat.getDetector().getId(), self.ccdNum)
 
     def testLinearizer(self):
-        lin1 = self.butler.get('linearizer', ccdnum=1)
-        lin2 = self.butler.get('linearizer', ccdnum=2)
+        lin1 = self.butler.get('linearizer', ccd=1)
+        lin2 = self.butler.get('linearizer', ccd=2)
         self.assertIsNotNone(lin1)
         self.assertIsNotNone(lin2)
         self.assertNotEqual(lin1, lin2)


### PR DESCRIPTION
Linearizers are now identical if created with no initialization parameters.  Pass through the detectorId when doing so.