### PR TITLE
DM-27168: Phase out use of FilterProperty

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -120,7 +120,7 @@ class GetDataTestCase(lsst.utils.tests.TestCase):
         raw = self.butler.get("raw", visit=self.visit, ccd=self.ccdNum)
         ccd = raw.getDetector()
         self.assertEqual(raw.getDimensions(), geom.Extent2I(*self.rawSize))
-        self.assertEqual(raw.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertEqual(raw.getFilter().getCanonicalName(), self.filter)
         self.assertEqual(ccd.getId(), self.ccdNum)
         self.assertEqual(ccd.getBBox().getDimensions(), geom.Extent2I(*self.ccdSize))
 


### PR DESCRIPTION
End usage of FilterProperty, as per RFC-730.