### PR TITLE
DM-30296: ap_verify HSC Gen 3 ingestion crashes on missing defineVisits config

### DIFF
--- a/config/datasetIngest-gen3.py
+++ b/config/datasetIngest-gen3.py
@@ -1,7 +1,0 @@
-# Config override for lsst.ap.verify.Gen3DatasetIngestTask
-
-import os.path
-
-configDir = os.path.dirname(__file__)
-
-config.visitDefiner.load(os.path.join(configDir, 'defineVisits.py'))


### PR DESCRIPTION
This PR removes a config override for `ap.verify.Gen3DatasetIngestTask` that is no longer necessary.