### PR TITLE
DM-30534: Set outlier tolerance parameter for jointcal

### DIFF
--- a/config/jointcal.py
+++ b/config/jointcal.py
@@ -13,3 +13,8 @@ config.colorterms.load(os.path.join(os.path.dirname(__file__), "colorterms.py"))
 # distortions along the edge of the field. Emperically, this provides a
 # measurably better fit than the default order=5.
 config.astrometryVisitOrder = 7
+
+# For the HSC deep fields with hundreds of visits, outlier rejection takes ~two
+# weeks of runtime. By stopping outlier rejection when it ceases to have a
+# significant effect on the model, we can bring compute time down to a few days.
+config.astrometryOutlierRelativeTolerance = 0.002


### PR DESCRIPTION
This sets the default for the jointcal config parameter `astrometryOutlierRelativeTolerance` to 0.002.