### PR TITLE
DM-29981: Migrate cp_pipe pipelines as defined in RFC-775

### DIFF
--- a/pipelines/cpBias.yaml
+++ b/pipelines/cpBias.yaml
@@ -1,4 +1,0 @@
-description: obs_subaru/HSC bias calibration construction
-instrument: lsst.obs.subaru.HyperSuprimeCam
-imports:
-  location: $CP_PIPE_DIR/pipelines/cpBias.yaml

--- a/pipelines/cpDark.yaml
+++ b/pipelines/cpDark.yaml
@@ -1,4 +1,0 @@
-description: obs_subaru/HSC dark calibration construction
-instrument: lsst.obs.subaru.HyperSuprimeCam
-imports:
-  location: $CP_PIPE_DIR/pipelines/cpDark.yaml

--- a/pipelines/cpFlat.yaml
+++ b/pipelines/cpFlat.yaml
@@ -1,4 +1,0 @@
-description: obs_subaru/HSC flat calibration construction
-instrument: lsst.obs.subaru.HyperSuprimeCam
-imports:
-  location: $CP_PIPE_DIR/pipelines/cpFlat.yaml

--- a/pipelines/cpFringe.yaml
+++ b/pipelines/cpFringe.yaml
@@ -1,4 +1,0 @@
-description: obs_subaru/HSC fringe calibration construction
-instrument: lsst.obs.subaru.HyperSuprimeCam
-imports:
-  location: $CP_PIPE_DIR/pipelines/cpFringe.yaml


### PR DESCRIPTION
Removing HSC calibration pipelines that have migrated to cp_pipe.