### PR TITLE
DM-31445: Enable GAaP PSF photometry before apCorr

### DIFF
--- a/config/charImage.py
+++ b/config/charImage.py
@@ -57,6 +57,7 @@ if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
     config.measureApCorr.allowFailure += names
 
 if "ext_gaap_GaapFlux" in config.measurement.plugins:
+    config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
     names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
     config.measureApCorr.allowFailure += names
 

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -16,6 +16,9 @@ config.measurement.plugins['base_PixelFlags'].masksFpAnywhere.append('BRIGHT_OBJ
 config.catalogCalculation.plugins.names = ["base_ClassificationExtendedness"]
 config.measurement.slots.psfFlux = "base_PsfFlux"
 
+# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
+
 def doUndeblended(config, algName, fluxList=None):
     """Activate undeblended measurements of algorithm
 
@@ -47,5 +50,3 @@ doUndeblended(config, "ext_gaap_GaapFlux",
 # Disable registration for apCorr of undeblended convolved; apCorr will be done through the deblended proxy
 config.measurement.undeblended["ext_convolved_ConvolvedFlux"].registerForApCorr = False
 config.measurement.undeblended["ext_gaap_GaapFlux"].registerForApCorr = False
-# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
-config.measurement.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True


### PR DESCRIPTION
`doPsfPhotometry` must be set to `True` before registering the plugin for
aperture corrections.