### PR TITLE
DM-31489: Update StrayLightData to use FitsGenericFormatter with a deferred data set

### DIFF
--- a/python/lsst/obs/subaru/strayLight/formatter.py
+++ b/python/lsst/obs/subaru/strayLight/formatter.py
@@ -19,14 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from lsst.daf.butler.formatters.file import FileFormatter
+# from lsst.daf.butler.formatters.fitsGeneric import FitsGenericFormatter
+from lsst.obs.base.formatters.fitsGeneric import FitsGenericFormatter
 
 from .yStrayLight import SubaruStrayLightData
 
 __all__ = ("SubaruStrayLightDataFormatter",)
 
 
-class SubaruStrayLightDataFormatter(FileFormatter):
+class SubaruStrayLightDataFormatter(FitsGenericFormatter):
     """Gen3 Butler Formatters for HSC y-band stray light correction data.
     """
     extension = ".fits"
@@ -35,7 +36,7 @@ class SubaruStrayLightDataFormatter(FileFormatter):
 
     def _readFile(self, path, pytype=None):
         # Docstring inherited from FileFormatter._readFile.
-        return SubaruStrayLightData(path)
+        return SubaruStrayLightData.readFits(path)
 
     def _writeFile(self, inMemoryDataset):
         # Docstring inherited from FileFormatter._writeFile.

--- a/python/lsst/obs/subaru/strayLight/formatter.py
+++ b/python/lsst/obs/subaru/strayLight/formatter.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# from lsst.daf.butler.formatters.fitsGeneric import FitsGenericFormatter
 from lsst.obs.base.formatters.fitsGeneric import FitsGenericFormatter
 
 from .yStrayLight import SubaruStrayLightData
@@ -30,14 +29,13 @@ __all__ = ("SubaruStrayLightDataFormatter",)
 class SubaruStrayLightDataFormatter(FitsGenericFormatter):
     """Gen3 Butler Formatters for HSC y-band stray light correction data.
     """
-    extension = ".fits"
 
     extension = ".fits"
 
     def _readFile(self, path, pytype=None):
-        # Docstring inherited from FileFormatter._readFile.
+        # Docstring inherited from FitsGenericFormatter._readFile.
         return SubaruStrayLightData.readFits(path)
 
     def _writeFile(self, inMemoryDataset):
-        # Docstring inherited from FileFormatter._writeFile.
+        # Docstring inherited from FitsGenericFormatter._writeFile.
         raise NotImplementedError("SubaruStrayLightData cannot be written directly.")

--- a/python/lsst/obs/subaru/strayLight/yStrayLight.py
+++ b/python/lsst/obs/subaru/strayLight/yStrayLight.py
@@ -33,7 +33,6 @@ from .rotatorAngle import inrStartEnd
 BAD_THRESHOLD = 500  # Threshold for identifying bad pixels in the reconstructed dark image
 
 
-# TODO DM-16805: This doesn't match the rest of the obs_subaru/ISR code.
 class SubaruStrayLightTask(StrayLightTask):
     """Remove stray light in the y-band
 
@@ -49,6 +48,7 @@ class SubaruStrayLightTask(StrayLightTask):
     This Task retrieves the appropriate dark, uncompresses it and
     uses it to remove the stray light from an exposure.
     """
+
     ConfigClass = StrayLightConfig
 
     def readIsrData(self, dataRef, rawExposure):
@@ -141,7 +141,7 @@ class SubaruStrayLightTask(StrayLightTask):
 
 
 class SubaruStrayLightData(StrayLightData):
-    """Lazy-load object that reads and integrates the wavelet-compressed
+    """Object that reads and integrates the wavelet-compressed
     HSC y-band stray-light model.
 
     Parameters
@@ -218,18 +218,22 @@ class SubaruStrayLightData(StrayLightData):
 
 
 def _upscale_image(img, target_shape, level):
-    """
-    Upscale the given image to `target_shape` .
+    """Upscale the given image to `target_shape` .
 
-    @param img (numpy.array[][])
-        Compressed image. `img.shape` must agree
+    Parameters
+    ----------
+    img : `numpy.array`, (Nx, Ny)
+        Compressed image. ``img.shape`` must agree
         with waveletCompression.scaled_size(target_shape, level)
-    @param target_shape ((int, int))
+    target_shape : `tuple` [`int`, `int`]
         The shape of upscaled image, which is to be returned.
-    @param level (int or tuple of int)
+    level : `int` or `tuple` [`int`]
         Level of multiresolution analysis (or synthesis)
 
-    @return (numpy.array[][])
+    Returns
+    -------
+    resized : `numpy.array`, (Nu, Nv)
+        Upscaled image with the ``target_shape``.
     """
     h, w = waveletCompression.scaled_size(target_shape, level)
 
@@ -240,19 +244,23 @@ def _upscale_image(img, target_shape, level):
 
 
 def _upscale_volume(volume, level):
-    """
-    Upscale the given volume (= sequence of images) along the 0-th axis,
-    and return an instance of a interpolation object that interpolates
-    the 0-th axis. The 0-th axis is the instrument rotation.
+    """Upscale the given volume (= sequence of images) along the 0-th
+    axis, and return an instance of a interpolation object that
+    interpolates the 0-th axis. The 0-th axis is the instrument
+    rotation.
 
-    @param volume (numpy.array[][][])
+    Parameters
+    ----------
+    volume : `numpy.array`, (Nx, Ny, Nz)
         Sequence of images.
-    @param level (int)
+    level : `int`
         Level of multiresolution analysis along the 0-th axis.
 
-    @return (scipy.interpolate.CubicSpline)
-        You get a slice of the volume at a specific angle (in degrees)
-        by calling the returned value as `ret_value(angle)` .
+    interpolator : callable
+        An object that returns a slice of the volume at a specific
+        angle (in degrees), with one positional argument:
+
+        - ``angle``: The angle in degrees.
     """
     angles = 720
     _, h, w = volume.shape

--- a/python/lsst/obs/subaru/strayLight/yStrayLight.py
+++ b/python/lsst/obs/subaru/strayLight/yStrayLight.py
@@ -24,6 +24,7 @@ from astropy.io import fits
 import scipy.interpolate
 
 from lsst.geom import Angle, degrees
+from lsst.daf.butler import DeferredDatasetHandle
 from lsst.ip.isr.straylight import StrayLightConfig, StrayLightTask, StrayLightData
 
 from . import waveletCompression
@@ -101,6 +102,10 @@ class SubaruStrayLightTask(StrayLightTask):
         if strayLightData is None:
             raise RuntimeError("No strayLightData supplied for correction.")
 
+        if isinstance(strayLightData, DeferredDatasetHandle):
+            # Get the deferred object.
+            strayLightData = strayLightData.get()
+
         exposureMetadata = exposure.getMetadata()
         detId = exposure.getDetector().getId()
         if self.config.doRotatorAngleCorrection:
@@ -162,7 +167,7 @@ class SubaruStrayLightData(StrayLightData):
         calib.setMetadata(hdulist[0].header)
 
         hdulist.close()
-
+        calib.log.info("Finished reading straylightData.")
         return calib
 
     def evaluate(self, angle_start: Angle, angle_end: Optional[Angle] = None):


### PR DESCRIPTION
This change makes the `SubaruStrayLightDataFormatter` a subclass of `FitsGenericFormatter`, and implements a `readFits` method to do so.  The reads differ between the butler generations:

* Gen2: `IsrTask.readIsrData` calls `SubaruStrayLightTask.readIsrData`, which checks if the exposure needs correcting, and if so, calls the `SubaruStrayLightData.readFits` method.  `SubaruStrayLightData.run` is called in the standard point in `IsrTask.run`.
* Gen3: A `DeferredDatasetHandle` is passed to `IsrTask.run` which calls `SubaruStrayLightData.run` at the standard point. The `run` method calls the same check method as in Gen2 (indicating this is run twice in Gen2), and if a correction is needed, converts the handle into the real object.

There are some slight naming clarifications (`hdulist` -> `calib.ampData`) and the docstrings in edited files have been converted to DM standards.