### PR TITLE
DM-32029: Add faro steps to DRP.yaml

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -231,7 +231,9 @@ subsets:
       - fgcmBuildStarsTable
       - fgcmFitCycle
       - fgcmOutputProducts
-      - faro_step2
+      - nsrcMeasVisit
+      - TE3
+      - TE4
     description: >
       Per-visit tasks that can be run together, but only after the 'step1'.
 
@@ -264,7 +266,33 @@ subsets:
       - healSparsePropertyMaps
       - selectGoodSeeingVisits
       - templateGen
-      - faro_step3
+      - matchCatalogsTract
+      - matchCatalogsPatch
+      - matchCatalogsPatchMultiBand
+      - PA1
+      - PF1_design
+      - AM1
+      - AM2
+      - AM3
+      - AD1_design
+      - AD2_design
+      - AD3_design
+      - AF1_design
+      - AF2_design
+      - AF3_design
+      - AB1
+      - modelPhotRepGal1
+      - modelPhotRepGal2
+      - modelPhotRepGal3
+      - modelPhotRepGal4
+      - modelPhotRepStar1
+      - modelPhotRepStar2
+      - modelPhotRepStar3
+      - modelPhotRepStar4
+      - psfPhotRepStar1
+      - psfPhotRepStar2
+      - psfPhotRepStar3
+      - psfPhotRepStar4
     description: >
       Tasks that can be run together, but only after the 'step1' and 'step2'
       subsets.
@@ -310,7 +338,9 @@ subsets:
     - writeForcedSourceOnDiaObjectTable
     - transformForcedSourceOnDiaObjectTable
     - consolidateForcedSourceOnDiaObjectTable
-    - faro_step5
+    - TE1
+    - TE2
+    - wPerp
     description: >
         Tasks that can be run together, but only after the 'step1', 'step2',
         'step3', and 'step4' subsets

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -161,6 +161,45 @@ subsets:
       The multiVisit subset defined in pipe_tasks' DRP.yaml is not safe to
       use on HSC for various reasons; use 'step1', 'step2', and 'step3' subsets
       instead.  It may be re-enabled in the future.
+  faro:
+    subset:
+      - nsrcMeasVisit
+      - TE3
+      - TE4
+      - matchCatalogsTract
+      - matchCatalogsPatch
+      - matchCatalogsPatchMultiBand
+      - PA1
+      - PF1_design
+      - AM1
+      - AM2
+      - AM3
+      - AD1_design
+      - AD2_design
+      - AD3_design
+      - AF1_design
+      - AF2_design
+      - AF3_design
+      - AB1
+      - modelPhotRepGal1
+      - modelPhotRepGal2
+      - modelPhotRepGal3
+      - modelPhotRepGal4
+      - modelPhotRepStar1
+      - modelPhotRepStar2
+      - modelPhotRepStar3
+      - modelPhotRepStar4
+      - psfPhotRepStar1
+      - psfPhotRepStar2
+      - psfPhotRepStar3
+      - psfPhotRepStar4
+      - TE1
+      - TE2
+      - wPerp
+    description: >
+      Set of tasks for calculation of metrics via faro. This includes tasks
+      that operate on single visits, matched visits, and coadds (and thus appear
+      in step2, step3, and step5 subsets below.
   step1:
     subset:
       - isr

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -2,6 +2,7 @@ description: The DRP pipeline specialized for the HSC instrument
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   - $PIPE_TASKS_DIR/pipelines/DRP.yaml
+  - $FARO_DIR/pipelines/metrics_pipeline_jointcal_fgcm.yaml
 tasks:
   skyCorr:
     class: lsst.pipe.drivers.skyCorrection.SkyCorrectionTask
@@ -182,6 +183,9 @@ subsets:
       - fgcmBuildStarsTable
       - fgcmFitCycle
       - fgcmOutputProducts
+      - nsrcMeasVisit
+      - TE3
+      - TE4
     description: >
       Per-visit tasks that can be run together, but only after the 'step1'.
 
@@ -214,6 +218,33 @@ subsets:
       - healSparsePropertyMaps
       - selectGoodSeeingVisits
       - templateGen
+      - matchCatalogsTract
+      - matchCatalogsPatch
+      - matchCatalogsPatchMultiBand
+      - PA1
+      - PF1_design
+      - AM1
+      - AM2
+      - AM3
+      - AD1_design
+      - AD2_design
+      - AD3_design
+      - AF1_design
+      - AF2_design
+      - AF3_design
+      - AB1
+      - modelPhotRepGal1
+      - modelPhotRepGal2
+      - modelPhotRepGal3
+      - modelPhotRepGal4
+      - modelPhotRepStar1
+      - modelPhotRepStar2
+      - modelPhotRepStar3
+      - modelPhotRepStar4
+      - psfPhotRepStar1
+      - psfPhotRepStar2
+      - psfPhotRepStar3
+      - psfPhotRepStar4
     description: >
       Tasks that can be run together, but only after the 'step1' and 'step2'
       subsets.
@@ -259,6 +290,9 @@ subsets:
     - writeForcedSourceOnDiaObjectTable
     - transformForcedSourceOnDiaObjectTable
     - consolidateForcedSourceOnDiaObjectTable
+    - TE1
+    - TE2
+    - wPerp
     description: >
         Tasks that can be run together, but only after the 'step1', 'step2',
         'step3', and 'step4' subsets

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -161,11 +161,16 @@ subsets:
       The multiVisit subset defined in pipe_tasks' DRP.yaml is not safe to
       use on HSC for various reasons; use 'step1', 'step2', and 'step3' subsets
       instead.  It may be re-enabled in the future.
-  faro:
+  faro_step2:
     subset:
       - nsrcMeasVisit
       - TE3
       - TE4
+    description: >
+      Set of tasks for calculation of metrics via faro. This includes tasks
+      that operate on single visits, and thus appear in step2 below.
+  faro_step3:
+    subset:
       - matchCatalogsTract
       - matchCatalogsPatch
       - matchCatalogsPatchMultiBand
@@ -193,13 +198,17 @@ subsets:
       - psfPhotRepStar2
       - psfPhotRepStar3
       - psfPhotRepStar4
+    description: >
+      Set of tasks for calculation of metrics via faro. This includes tasks
+      that operate on matched visits, and thus appear in step3 below.
+  faro_step5:
+    subset:
       - TE1
       - TE2
       - wPerp
     description: >
       Set of tasks for calculation of metrics via faro. This includes tasks
-      that operate on single visits, matched visits, and coadds (and thus appear
-      in step2, step3, and step5 subsets below.
+      that operate on coadds, and thus appear in step5 below.
   step1:
     subset:
       - isr
@@ -222,9 +231,7 @@ subsets:
       - fgcmBuildStarsTable
       - fgcmFitCycle
       - fgcmOutputProducts
-      - nsrcMeasVisit
-      - TE3
-      - TE4
+      - faro_step2
     description: >
       Per-visit tasks that can be run together, but only after the 'step1'.
 
@@ -257,33 +264,7 @@ subsets:
       - healSparsePropertyMaps
       - selectGoodSeeingVisits
       - templateGen
-      - matchCatalogsTract
-      - matchCatalogsPatch
-      - matchCatalogsPatchMultiBand
-      - PA1
-      - PF1_design
-      - AM1
-      - AM2
-      - AM3
-      - AD1_design
-      - AD2_design
-      - AD3_design
-      - AF1_design
-      - AF2_design
-      - AF3_design
-      - AB1
-      - modelPhotRepGal1
-      - modelPhotRepGal2
-      - modelPhotRepGal3
-      - modelPhotRepGal4
-      - modelPhotRepStar1
-      - modelPhotRepStar2
-      - modelPhotRepStar3
-      - modelPhotRepStar4
-      - psfPhotRepStar1
-      - psfPhotRepStar2
-      - psfPhotRepStar3
-      - psfPhotRepStar4
+      - faro_step3
     description: >
       Tasks that can be run together, but only after the 'step1' and 'step2'
       subsets.
@@ -329,9 +310,7 @@ subsets:
     - writeForcedSourceOnDiaObjectTable
     - transformForcedSourceOnDiaObjectTable
     - consolidateForcedSourceOnDiaObjectTable
-    - TE1
-    - TE2
-    - wPerp
+    - faro_step5
     description: >
         Tasks that can be run together, but only after the 'step1', 'step2',
         'step3', and 'step4' subsets

--- a/pipelines/DRPFakes.yaml
+++ b/pipelines/DRPFakes.yaml
@@ -19,9 +19,6 @@ imports:
     - drpAssociation
     - drpDiaCalculation
     - forcedPhotDiffim
-    - faro_step2
-    - faro_step3
-    - faro_step5
 tasks:
   processCcdWithFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithFakesTask

--- a/pipelines/DRPFakes.yaml
+++ b/pipelines/DRPFakes.yaml
@@ -19,6 +19,9 @@ imports:
     - drpAssociation
     - drpDiaCalculation
     - forcedPhotDiffim
+    - faro_step2
+    - faro_step3
+    - faro_step5
 tasks:
   processCcdWithFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithFakesTask


### PR DESCRIPTION
Successful Jenkins run is at https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/35175/pipeline/

The blocker (DM-32059) has been completed and merged - that ticket removed the unused `faro` tasks from the main pipelines so they wouldn't cause problems in `obs_subaru`. 