### PR TITLE
DM-34693: add instrument config for SkyBotEphemerisQueryTask

### DIFF
--- a/config/SkyBotEphemerisQuery.py
+++ b/config/SkyBotEphemerisQuery.py
@@ -1,0 +1,4 @@
+# HSC-specific config for lsst.ap.association.skyBotEphemerisQuery.SkyBotEphemerisQueryTask
+
+config.observerCode = "T09"        # IAU code for Subaru
+config.queryRadiusDegrees = 0.9    # HSC FoV radius + 20% margin


### PR DESCRIPTION
This PR adds an instrument-level config override file for `lsst.ap.association.skyBotEphemerisQuery.SkyBotEphemerisQueryTask`. I'm fairly confident that these values are appropriate for all HSC data sets and for all pipelines.