### PR TITLE
DM-12659: Fix C++ import of pure-Python package

### DIFF
--- a/ups/obs_subaru.cfg
+++ b/ups/obs_subaru.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "afw", "obs_base"],
+    "required": ["cpputils", "afw", "obs_base"],
     "buildRequired": ["pybind11"],
 }
 


### PR DESCRIPTION
This PR stops C++ imports of `utils`, which as a pure-Python package no longer supports such imports. It's `cpputils` that could produce headers and libraries.