### PR TITLE
DM-33429: Add ability to do both serial and parallel overscan correction

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -26,13 +26,6 @@ config.doOverscan = True
 config.overscan.fitType = "AKIMA_SPLINE"
 config.overscan.order = 30
 config.overscan.numSigmaClip = 3.0
-config.overscanNumLeadingColumnsToSkip = 0
-config.overscanNumTrailingColumnsToSkip = 0
-config.overscanMaxDev = 1000.0
-config.overscanBiasJump = False
-config.overscanBiasJumpKeyword = "NO_SUCH_KEY"
-config.overscanBiasJumpDevices = "NO_SUCH_KEY"
-config.overscanBiasJumpLocation = -1
 
 config.doAssembleCcd = True
 # Use default ISR assembleCcdTask

--- a/config/makeBrighterFatterKernel.py
+++ b/config/makeBrighterFatterKernel.py
@@ -19,8 +19,8 @@ config.isr.doSaturation = True
 config.isr.qa.doThumbnailOss = False
 config.isr.qa.doThumbnailFlattened = False
 config.isr.fringe.filters = ['HSC-Y', ]
-config.isr.overscanFitType = "AKIMA_SPLINE"
-config.isr.overscanOrder = 30
+config.isr.overscan.fitType = "AKIMA_SPLINE"
+config.isr.overscan.order = 30
 # Overscan is fairly efficient at removing bias level, but leaves a line in the middle
 
 config.isr.doStrayLight = False  # added to work around the missing INST-PA throw in some visits


### PR DESCRIPTION
Switch config file to use current overscan config options instead of deprecated isrTask config options.