### PR TITLE
DM-35656: add analysis_tools to drp_pipe and run in ci_imsim

### DIFF
--- a/config/objectTableTractAnalysis.py
+++ b/config/objectTableTractAnalysis.py
@@ -1,0 +1,7 @@
+import os.path
+from lsst.pipe.tasks.postprocess import TransformObjectCatalogConfig
+
+# By default loop over all the same bands that are present in the Object Table
+objectConfig = TransformObjectCatalogConfig()
+objectConfig.load(os.path.join(os.path.dirname(__file__), "transformObjectCatalog.py"))
+config.bands = objectConfig.outputBands


### PR DESCRIPTION
Analyze same list of bands as produced in Object Table
transformObjectTable explodes out the bands listed in the outputBands
config parameter. Therefore a sensible default for objectTableTractAnalysis
is to make plots and metrics for that same list of bands