### PR TITLE
DM-39306: Log amp pedestals with more precision.

### DIFF
--- a/python/lsst/obs/subaru/ampOffset.py
+++ b/python/lsst/obs/subaru/ampOffset.py
@@ -147,4 +147,4 @@ class SubaruAmpOffsetTask(AmpOffsetTask):
                 metadata.set(f"PEDESTAL{ii + 1}",
                              float(pedestal),
                              f"Pedestal level subtracted from amp {ii + 1}")
-            self.log.info(f"amp pedestal values: {', '.join([f'{x:.2f}' for x in pedestals])}")
+            self.log.info(f"amp pedestal values: {', '.join([f'{x:.4f}' for x in pedestals])}")


### PR DESCRIPTION
In the course of debugging, I found that increasing the precision of the logging of the amp offset pedestals was useful, so I put it on this ticket.