### PR TITLE
DM-35579: Remove pipelines forwarding stubs.

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2.yaml

--- a/pipelines/DRPFakes.yaml
+++ b/pipelines/DRPFakes.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2+fakes.yaml

--- a/pipelines/makeQaTractTables.yaml
+++ b/pipelines/makeQaTractTables.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/pipelines/HSC/QaTractTables.yaml


### PR DESCRIPTION
Pipelines should go in *_pipe packages.