### PR TITLE
DM-46642: Use same band order for all instances of isolatedStarAssociation

### DIFF
--- a/config/isolatedStarAssociation.py
+++ b/config/isolatedStarAssociation.py
@@ -1,0 +1,2 @@
+# irgzyN921 is preferred order of Eli and tested in RC2
+config.band_order = ["i", "r", "g", "z", "y", "N921", "N816", "N1010", "N387", "N515"]


### PR DESCRIPTION
Now that we run isolatedStarAssociation twice, its worth defining the band order once here for all HSC pipelines.