### PR TITLE
DM-51429: Add config override to bgModel2.minFrac

### DIFF
--- a/config/skyCorr.py
+++ b/config/skyCorr.py
@@ -4,6 +4,7 @@ config.bgModel1.load(os.path.join(os.path.dirname(__file__), "focalPlaneBackgrou
 config.bgModel2.xSize = 256 * 0.015  # in mm
 config.bgModel2.ySize = 256 * 0.015  # in mm
 config.bgModel2.pixelSize = 0.015  # mm per pixel
+config.bgModel2.minFrac = 0.5
 
 # Detection overrides to keep results the same post DM-39796
 config.maskObjects.detection.doTempLocalBackground = False


### PR DESCRIPTION
On DM-51429, the task default for bgModel2.minFrac was changed to 0.3. This change was made to facilitate skyCorr processing for LSSTCam data, whereby crowded fields make the existing default of 0.5 too high. To preserve HSC behaviour, an HSC-specific config override is set here to maintain a value of bgModel2.minFrac=0.5.